### PR TITLE
Refactor & Command tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,16 +75,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
 
 [[package]]
 name = "clap"
@@ -118,6 +168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,10 +218,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "js-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -180,16 +268,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
+name = "num-traits"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nvmd"
 version = "2.2.0"
 dependencies = [
  "cfg-if",
+ "chrono",
  "clap",
  "dirs",
  "fs_extra",
@@ -198,6 +302,12 @@ dependencies = [
  "serde_json",
  "version-compare",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "option-ext"
@@ -369,6 +479,69 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "nvmd"
-version = "0.1.0"
+version = "2.2.0"
 dependencies = [
  "cfg-if",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +70,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "dirs"
@@ -62,6 +156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,11 +190,13 @@ name = "nvmd"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "clap",
  "dirs",
  "fs_extra",
  "lazy_static",
  "regex",
  "serde_json",
+ "version-compare",
 ]
 
 [[package]]
@@ -208,6 +310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +351,18 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 
 [dependencies]
 cfg-if = "1.0.0"
+clap = { version = "4.4.4", features = ["derive"] }
 dirs = "5.0.1"
 fs_extra = "1.3.0"
 lazy_static = "1.4.0"
 regex = "1.9.5"
 serde_json = "1.0.105"
+version-compare = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["The1111mp@outlook.com"]
 
 [dependencies]
 cfg-if = "1.0.0"
+chrono = "0.4.31"
 clap = { version = "4.4.4", features = ["derive"] }
 dirs = "5.0.1"
 fs_extra = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "nvmd"
-version = "0.1.0"
+version = "2.2.0"
 edition = "2021"
+authors = ["The1111mp@outlook.com"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,91 @@
 
 Provides services for [nvm-desktop](https://github.com/1111mp/nvm-desktop)'s Node engine version management function.
 
-### How does it work?
+You can also manage all versions of node directly from the command line. But if you need to download and install a new version of node, you should open the `nvm-desktop` application.
+
+## Command tools intro
+
+`nvmd` allows you to quickly manage different versions of node via the command line.
+
+```shell
+$ nvmd use 18.17.1
+Now using node v18.17.1
+$ node -v
+v18.17.1
+$ nvmd use v20.5.1 --project
+Now using node v20.5.1
+$ node -v
+v20.5.1
+$ nvmd ls
+v20.6.1
+v20.5.1 (currently)
+v18.17.1
+$ nvmd current
+v20.5.1
+```
+
+Simple as that!
+
+## Usage
+
+Please download and install the latest release of node in the `nvm-desktop` application.
+
+```shell
+$ nvmd --help
+nvmd (2.2.0)
+The1111mp@outlook.com
+command tools for nvm-desktop
+
+Usage: nvmd [COMMAND]
+
+Commands:
+  current  Get the currently used version
+  list     List the all installed versions of Node.js
+  ls       List the all installed versions of Node.js
+  use      Use the installed version of Node.js (default is global)
+  which    Get the path to the executable to where Node.js was installed
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+
+Please download new version of Node.js in nvm-desktop.
+```
+
+You can list all installed versions using `list` or `ls`:
+
+```shell
+nvmd list
+# or
+nvmd ls
+```
+
+And then in any new shell just use the installed version:
+
+```shell
+nvmd use node_version
+```
+
+Or you can run it directly using the node version for your project:
+
+```shell
+nvmd use node_version --project
+```
+
+You can get the version you are currently using:
+
+```shell
+nvmd current
+```
+
+You can also get the path to the executable to where it was installed:
+
+```shell
+nvmd which 18.17.1
+```
+
+## How does it work?
 
 `nvmd-comand` does not use any fancy OS features or shell-specific hooks. It’s built on the simple, proven approach of shims.
 
@@ -39,7 +123,7 @@ When uninstalling global packages, this information will be used to determine wh
 
 This ensures the independence of each version of the Node engine, and they will not affect each other.
 
-### Build nvmd-command
+## Build nvmd-command
 
 - First, you should have a Rust runtime installed locally. Please read the official guide: [rust get-started](https://www.rust-lang.org/learn/get-started).
 - Then pull the project code locally, go to the `./` folder.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,113 @@
+use std::{env, ffi::OsString, io::ErrorKind, path::PathBuf, process::ExitStatus};
+
+use fs_extra::file::read_to_string;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref NVMD_PATH: PathBuf = get_nvmd_path();
+    pub static ref VERSION: String = get_version();
+    pub static ref ENV_PATH: OsString = get_env_path();
+}
+
+fn get_env_path() -> OsString {
+    let bin_path = get_bin_path();
+
+    let path = match env::var_os("PATH") {
+        Some(path) => {
+            let mut paths = env::split_paths(&path).collect::<Vec<_>>();
+
+            paths.insert(0, PathBuf::from(bin_path));
+
+            let env_path = match env::join_paths(paths) {
+                Ok(p) => p,
+                Err(_) => OsString::from(""),
+            };
+
+            return env_path;
+        }
+        None => bin_path,
+    };
+
+    return path;
+}
+
+fn get_bin_path() -> OsString {
+    let mut nvmd_path = NVMD_PATH.clone();
+    nvmd_path.push("versions");
+    nvmd_path.push(VERSION.clone());
+
+    if cfg!(unix) {
+        nvmd_path.push("bin");
+    }
+
+    let bin_path = nvmd_path.into_os_string();
+
+    return bin_path;
+}
+
+fn get_version() -> String {
+    let mut nvmdrc = match env::current_dir() {
+        Err(_) => PathBuf::from(""),
+        Ok(dir) => dir,
+    };
+    nvmdrc.push(".nvmdrc");
+
+    let project_version = match read_to_string(&nvmdrc) {
+        Err(_) => String::from(""),
+        Ok(v) => v,
+    };
+
+    if !project_version.is_empty() {
+        return project_version;
+    }
+
+    let mut default_path = NVMD_PATH.clone();
+    default_path.push("default");
+
+    let default_version = match read_to_string(&default_path) {
+        Err(_) => String::from(""),
+        Ok(v) => v,
+    };
+
+    return default_version;
+}
+
+fn get_nvmd_path() -> PathBuf {
+    let nvmd_path = match default_home_dir() {
+        Ok(p) => p,
+        Err(_) => PathBuf::from(""),
+    };
+
+    return nvmd_path;
+}
+
+fn default_home_dir() -> Result<PathBuf, ErrorKind> {
+    let mut home = dirs::home_dir().ok_or(ErrorKind::NotFound)?;
+    home.push(".nvmd");
+    Ok(home)
+}
+
+pub enum Error {
+    Message(String),
+    Code(i32),
+}
+
+pub trait IntoResult<T> {
+    fn into_result(self) -> Result<T, Error>;
+}
+
+impl IntoResult<()> for Result<ExitStatus, String> {
+    fn into_result(self) -> Result<(), Error> {
+        match self {
+            Ok(status) => {
+                if status.success() {
+                    Ok(())
+                } else {
+                    let code = status.code().unwrap_or(1);
+                    Err(Error::Code(code))
+                }
+            }
+            Err(err) => Err(Error::Message(err)),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,83 +1,24 @@
-use std::{env, ffi::OsString, process};
-
-use crate::nvmd::{ENV_PATH, NVMD_PATH, VERSION};
-use lazy_static::lazy_static;
+use std::process;
 
 mod command;
-mod nvmd;
+mod common;
+mod run;
 
-lazy_static! {
-    static ref INSTALL: OsString = OsString::from("install");
-    static ref UNINSTALL: OsString = OsString::from("uninstall");
-    static ref GLOBAL: OsString = OsString::from("--global");
-    static ref SHORT_GLOBAL: OsString = OsString::from("-g");
-}
+use common::{Error, IntoResult};
+use run::execute;
 
 fn main() {
-    let mut native_args = env::args_os();
-    let exe = nvmd::get_tool_name(&mut native_args).expect("get tool name error");
-    let args: Vec<_> = native_args.collect();
-
-    let lib = match exe.clone().into_string() {
-        Ok(s) => s,
-        Err(_) => String::from(""),
-    };
-
-    if !lib.is_empty() && lib != "node" && lib != "npm" && lib != "npx" && lib != "corepack" {
-        // check the third package
-        let mut lib_path = NVMD_PATH.clone();
-        lib_path.push("versions");
-        lib_path.push(VERSION.clone());
-        if cfg!(unix) {
-            // unix
-            lib_path.push("bin");
+    let result = execute().into_result();
+    match result {
+        Ok(()) => {
+            process::exit(0);
         }
-        lib_path.push(&lib);
-
-        if !lib_path.exists() {
-            println!("[nvm-desktop] command not found: {}", &lib);
+        Err(Error::Code(code)) => {
+            process::exit(code);
+        }
+        Err(Error::Message(msg)) => {
+            eprintln!("nvm-desktop: {}", msg);
             process::exit(1);
         }
     }
-
-    // for npm uninstall -g packages
-    // collection the bin names of packages
-    if lib == "npm"
-        && args.contains(&UNINSTALL)
-        && (args.contains(&GLOBAL) || args.contains(&SHORT_GLOBAL))
-    {
-        nvmd::collection_packages_name(&args);
-    }
-
-    let mut command = command::create_command(&exe);
-
-    let child = command
-        .env("PATH", ENV_PATH.clone())
-        .args(&args)
-        .spawn()
-        .expect("command failed to start");
-
-    let output = child.wait_with_output().expect("failed to wait on child");
-
-    let code = match output.status.success() {
-        true => 0,
-        false => 1,
-    };
-
-    if code == 0 {
-        // successed
-        if (args.contains(&INSTALL) || args.contains(&UNINSTALL))
-            && (args.contains(&SHORT_GLOBAL) || args.contains(&GLOBAL))
-        {
-            if args.contains(&INSTALL) {
-                nvmd::install_packages(&args);
-            }
-
-            if args.contains(&UNINSTALL) {
-                nvmd::uninstall_packages();
-            }
-        }
-    }
-
-    process::exit(code);
 }

--- a/src/run/binary.rs
+++ b/src/run/binary.rs
@@ -1,0 +1,31 @@
+use super::{ExitStatus, OsStr, OsString};
+
+use crate::{
+    command as CommandTool,
+    common::{ENV_PATH, NVMD_PATH, VERSION},
+};
+
+pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, String> {
+    let mut lib_path = NVMD_PATH.clone();
+    lib_path.push("versions");
+    lib_path.push(VERSION.clone());
+    if cfg!(unix) {
+        // unix
+        lib_path.push("bin");
+    }
+    lib_path.push(exe);
+
+    if !lib_path.exists() {
+        return Err(String::from("command not found: ") + exe.to_str().unwrap());
+    }
+
+    let child = CommandTool::create_command(exe)
+        .env("PATH", ENV_PATH.clone())
+        .args(args)
+        .status();
+
+    match child {
+        Ok(status) => Ok(status),
+        Err(_) => Err(String::from("failed to execute process")),
+    }
+}

--- a/src/run/engine.rs
+++ b/src/run/engine.rs
@@ -1,0 +1,15 @@
+use super::{ExitStatus, OsStr, OsString};
+
+use crate::{command as CommandTool, common::ENV_PATH};
+
+pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, String> {
+    let child = CommandTool::create_command(exe)
+        .env("PATH", ENV_PATH.clone())
+        .args(args)
+        .status();
+
+    match child {
+        Ok(status) => Ok(status),
+        Err(_) => Err(String::from("failed to execute process")),
+    }
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,0 +1,47 @@
+use std::{
+    env::{self, ArgsOs},
+    ffi::{OsStr, OsString},
+    io::{Error, ErrorKind},
+    path::Path,
+    process::ExitStatus,
+};
+
+mod binary;
+mod engine;
+mod npm;
+mod nvmd;
+
+pub fn execute() -> Result<ExitStatus, String> {
+    let mut native_args = env::args_os();
+    let exe = get_tool_name(&mut native_args).expect("get tool name error");
+    let args: Vec<_> = native_args.collect();
+
+    match exe.to_str() {
+        Some("nvmd") => nvmd::command(),
+        Some("npm") => npm::command(&exe, &args),
+        Some("node") | Some("npx") | Some("corepack") => engine::command(&exe, &args),
+        _ => binary::command(&exe, &args),
+    }
+}
+
+fn get_tool_name(args: &mut ArgsOs) -> Result<OsString, Error> {
+    args.next()
+        .and_then(|arg0| Path::new(&arg0).file_name().map(tool_name_from_file_name))
+        .ok_or_else(|| ErrorKind::InvalidInput.into())
+}
+
+#[cfg(unix)]
+fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
+    file_name.to_os_string()
+}
+
+#[cfg(windows)]
+fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
+    // On Windows PowerShell, the file name includes the .exe suffix,
+    // and the Windows file system is case-insensitive
+    // We need to remove that to get the raw tool name
+    match file_name.to_str() {
+        Some(file) => OsString::from(file.to_ascii_lowercase().trim_end_matches(".exe")),
+        None => OsString::from(file_name),
+    }
+}

--- a/src/run/npm.rs
+++ b/src/run/npm.rs
@@ -1,134 +1,78 @@
-#[cfg(unix)]
-use std::os::unix::fs;
-use std::{
-    env::{self, ArgsOs},
-    ffi::{OsStr, OsString},
-    io::{BufRead, BufReader, Error, ErrorKind},
-    path::{Path, PathBuf},
-    process::Stdio,
-    sync::Mutex,
-};
-
 use fs_extra::file::{read_to_string, remove, write_all};
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde_json::{from_str, json, Value};
+#[cfg(unix)]
+use std::os::unix::fs;
+use std::{
+    io::{BufRead, BufReader},
+    path::PathBuf,
+    process::Stdio,
+    sync::Mutex,
+};
 
-use crate::command;
+use super::{ExitStatus, OsStr, OsString};
+use crate::{
+    command as CommandTool,
+    common::{ENV_PATH, NVMD_PATH, VERSION},
+};
 
 lazy_static! {
-    pub static ref NVMD_PATH: PathBuf = get_nvmd_path();
-    pub static ref VERSION: String = get_version();
-    pub static ref ENV_PATH: OsString = get_env_path();
+    static ref INSTALL: OsString = OsString::from("install");
+    static ref UNINSTALL: OsString = OsString::from("uninstall");
+    static ref GLOBAL: OsString = OsString::from("--global");
+    static ref SHORT_GLOBAL: OsString = OsString::from("-g");
     pub static ref UNINSTALL_PACKAGES_NAME: Mutex<Vec<String>> = {
         let m = Vec::new();
         Mutex::new(m)
     };
 }
 
-/// Determine the name of the command to run by inspecting the first argument to the active process
-pub fn get_tool_name(args: &mut ArgsOs) -> Result<OsString, Error> {
-    args.next()
-        .and_then(|arg0| Path::new(&arg0).file_name().map(tool_name_from_file_name))
-        .ok_or_else(|| ErrorKind::InvalidInput.into())
-}
+pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, String> {
+    let is_global = args.contains(&SHORT_GLOBAL) || args.contains(&GLOBAL);
+    let is_global_install = is_global && args.contains(&INSTALL);
+    let is_global_uninstall = is_global && args.contains(&UNINSTALL);
 
-#[cfg(unix)]
-fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
-    file_name.to_os_string()
-}
-
-#[cfg(windows)]
-fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
-    // On Windows PowerShell, the file name includes the .exe suffix,
-    // and the Windows file system is case-insensitive
-    // We need to remove that to get the raw tool name
-    match file_name.to_str() {
-        Some(file) => OsString::from(file.to_ascii_lowercase().trim_end_matches(".exe")),
-        None => OsString::from(file_name),
+    // for npm uninstall -g packages
+    // collection the bin names of packages
+    if is_global_uninstall {
+        collection_packages_name(args);
     }
-}
 
-pub fn get_env_path() -> OsString {
-    let bin_path = get_bin_path();
+    let child = CommandTool::create_command(exe)
+        .env("PATH", ENV_PATH.clone())
+        .args(args)
+        .status();
 
-    let path = match env::var_os("PATH") {
-        Some(path) => {
-            let mut paths = env::split_paths(&path).collect::<Vec<_>>();
+    // npm install/uninstall -g packages
 
-            paths.insert(0, PathBuf::from(bin_path));
+    match child {
+        Ok(status) => {
+            if status.success() {
+                // npm install -g packages
+                if is_global_install {
+                    global_install_packages(args);
+                }
 
-            let env_path = match env::join_paths(paths) {
-                Ok(p) => p,
-                Err(_) => OsString::from(""),
-            };
+                // npm uninstall -g packages
+                if is_global_uninstall {
+                    global_uninstall_packages();
+                }
+            }
 
-            return env_path;
+            Ok(status)
         }
-        None => bin_path,
-    };
-
-    return path;
-}
-
-fn get_bin_path() -> OsString {
-    let mut nvmd_path = NVMD_PATH.clone();
-    nvmd_path.push("versions");
-    nvmd_path.push(VERSION.clone());
-
-    if cfg!(unix) {
-        nvmd_path.push("bin");
+        Err(_) => Err(String::from("failed to execute process")),
     }
-
-    let bin_path = nvmd_path.into_os_string();
-
-    return bin_path;
 }
 
-pub fn get_version() -> String {
-    let mut nvmdrc = match env::current_dir() {
-        Err(_) => PathBuf::from(""),
-        Ok(dir) => dir,
-    };
-    nvmdrc.push(".nvmdrc");
-
-    let project_version = match read_to_string(&nvmdrc) {
-        Err(_) => String::from(""),
-        Ok(v) => v,
-    };
-
-    if !project_version.is_empty() {
-        return project_version;
-    }
-
-    let mut default_path = NVMD_PATH.clone();
-    default_path.push("default");
-
-    let default_version = match read_to_string(&default_path) {
-        Err(_) => String::from(""),
-        Ok(v) => v,
-    };
-
-    return default_version;
-}
-
-pub fn get_nvmd_path() -> PathBuf {
-    let nvmd_path = match default_home_dir() {
-        Ok(p) => p,
-        Err(_) => PathBuf::from(""),
-    };
-
-    return nvmd_path;
-}
-
-pub fn install_packages(args: &Vec<OsString>) {
+fn global_install_packages(args: &[OsString]) {
     let re: Regex = Regex::new(r"@[0-9]|@latest").unwrap();
     let packages = &args
         .into_iter()
         .filter(is_positional)
         .map(|x| {
             let package = String::from(x.to_str().unwrap());
-            // let mat = re.find(&package).unwrap();
 
             let new_package = match re.find(&package) {
                 None => OsString::from(&package),
@@ -154,7 +98,7 @@ pub fn install_packages(args: &Vec<OsString>) {
     }
 }
 
-pub fn uninstall_packages() {
+fn global_uninstall_packages() {
     let names = UNINSTALL_PACKAGES_NAME.lock().unwrap();
     for name in names.iter() {
         if record_uninstall_package(name) {
@@ -162,64 +106,6 @@ pub fn uninstall_packages() {
             unlink_package(name);
         }
     }
-}
-
-#[cfg(unix)]
-fn unlink_package(name: &String) {
-    let mut alias = NVMD_PATH.clone();
-    alias.push("bin");
-    alias.push(name);
-
-    remove(alias).unwrap_or_else(|_why| {});
-}
-
-#[cfg(windows)]
-fn unlink_package(name: &String) {
-    let mut exe_alias = NVMD_PATH.clone();
-    exe_alias.push("bin");
-    let exe = name.clone() + ".exe";
-    exe_alias.push(exe);
-    let mut cmd_alias = NVMD_PATH.clone();
-    cmd_alias.push("bin");
-    let cmd = name.clone() + ".cmd";
-    cmd_alias.push(cmd);
-
-    remove(exe_alias).unwrap_or_else(|_why| {});
-    remove(cmd_alias).unwrap_or_else(|_why| {});
-}
-
-pub fn collection_packages_name(args: &Vec<OsString>) {
-    let re: Regex = Regex::new(r"@[0-9]|@latest").unwrap();
-    let packages = &args
-        .into_iter()
-        .filter(is_positional)
-        .map(|x| {
-            let package = String::from(x.to_str().unwrap());
-            // let mat = re.find(&package).unwrap();
-
-            let new_package = match re.find(&package) {
-                None => OsString::from(&package),
-                Some(mat) => {
-                    let str = &package[0..(mat.start())];
-
-                    return OsString::from(str);
-                }
-            };
-
-            return OsString::from(new_package);
-        })
-        .collect();
-
-    let npm_perfix = get_npm_perfix();
-
-    let package_bin_names = get_package_bin_names(&npm_perfix, packages);
-
-    let mut global_names = UNINSTALL_PACKAGES_NAME.lock().unwrap();
-    for name in package_bin_names {
-        global_names.push(name);
-    }
-
-    // return package_bin_names;
 }
 
 fn record_installed_package(packages: &Vec<String>) {
@@ -315,6 +201,61 @@ fn record_uninstall_package(name: &String) -> bool {
     return record;
 }
 
+fn collection_packages_name(args: &[OsString]) {
+    let re: Regex = Regex::new(r"@[0-9]|@latest").unwrap();
+    let packages = &args
+        .into_iter()
+        .filter(is_positional)
+        .map(|x| {
+            let package = String::from(x.to_str().unwrap());
+            // let mat = re.find(&package).unwrap();
+
+            let new_package = match re.find(&package) {
+                None => OsString::from(&package),
+                Some(mat) => {
+                    let str = &package[0..(mat.start())];
+
+                    return OsString::from(str);
+                }
+            };
+
+            return OsString::from(new_package);
+        })
+        .collect();
+
+    let npm_perfix = get_npm_perfix();
+
+    let package_bin_names = get_package_bin_names(&npm_perfix, packages);
+
+    let mut global_names = UNINSTALL_PACKAGES_NAME.lock().unwrap();
+    for name in package_bin_names {
+        global_names.push(name);
+    }
+}
+
+fn get_npm_perfix() -> String {
+    let mut command = CommandTool::create_command("npm");
+
+    let child = command
+        .env("PATH", ENV_PATH.clone())
+        .args(["root", "-g"])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("nvmd-desktop: get npm perfix error");
+
+    let output = child.stdout.unwrap();
+    let lines = BufReader::new(output).lines();
+    let mut perfix = String::from("");
+    for line in lines {
+        let cur_line = line.unwrap();
+        if cur_line.contains(".nvmd") {
+            perfix = cur_line;
+        }
+    }
+
+    return perfix;
+}
+
 fn get_package_bin_names(npm_perfix: &String, packages: &Vec<OsString>) -> Vec<String> {
     let mut package_bin_names: Vec<String> = vec![];
 
@@ -345,29 +286,6 @@ fn get_package_bin_names(npm_perfix: &String, packages: &Vec<OsString>) -> Vec<S
     }
 
     return package_bin_names;
-}
-
-fn get_npm_perfix() -> String {
-    let mut command = command::create_command("npm");
-
-    let child = command
-        .env("PATH", ENV_PATH.clone())
-        .args(["root", "-g"])
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("get npm perfix error");
-
-    let output = child.stdout.unwrap();
-    let lines = BufReader::new(output).lines();
-    let mut perfix = String::from("");
-    for line in lines {
-        let cur_line = line.unwrap();
-        if cur_line.contains(".nvmd") {
-            perfix = cur_line;
-        }
-    }
-
-    return perfix;
 }
 
 #[cfg(unix)]
@@ -408,10 +326,28 @@ fn link_package(name: &String) {
     copy(&cmd_source, &cmd_alias, &options).unwrap();
 }
 
-fn default_home_dir() -> Result<PathBuf, ErrorKind> {
-    let mut home = dirs::home_dir().ok_or(ErrorKind::NotFound)?;
-    home.push(".nvmd");
-    Ok(home)
+#[cfg(unix)]
+fn unlink_package(name: &String) {
+    let mut alias = NVMD_PATH.clone();
+    alias.push("bin");
+    alias.push(name);
+
+    remove(alias).unwrap_or_else(|_why| {});
+}
+
+#[cfg(windows)]
+fn unlink_package(name: &String) {
+    let mut exe_alias = NVMD_PATH.clone();
+    exe_alias.push("bin");
+    let exe = name.clone() + ".exe";
+    exe_alias.push(exe);
+    let mut cmd_alias = NVMD_PATH.clone();
+    cmd_alias.push("bin");
+    let cmd = name.clone() + ".cmd";
+    cmd_alias.push(cmd);
+
+    remove(exe_alias).unwrap_or_else(|_why| {});
+    remove(cmd_alias).unwrap_or_else(|_why| {});
 }
 
 fn is_flag<A>(arg: &A) -> bool
@@ -424,7 +360,7 @@ where
     }
 }
 
-pub fn is_positional<A>(arg: &A) -> bool
+fn is_positional<A>(arg: &A) -> bool
 where
     A: AsRef<OsStr>,
 {

--- a/src/run/nvmd.rs
+++ b/src/run/nvmd.rs
@@ -1,0 +1,198 @@
+use super::ExitStatus;
+use clap::{Parser, Subcommand};
+use fs_extra::{
+    dir::{ls, DirEntryAttr, DirEntryValue},
+    error::Error,
+    file::write_all,
+};
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+#[cfg(windows)]
+use std::os::windows::process::ExitStatusExt;
+use std::{cmp::Ordering, collections::HashSet, env};
+use version_compare::{compare, Cmp};
+
+use crate::common::{NVMD_PATH, VERSION};
+
+#[derive(Parser)]
+#[command(name="nvmd", author="The1111mp@outlook.com", version="2.2.0", about="command tools for nvm-desktop", after_help="Please download new version of Node.js in nvm-desktop.", long_about = None)]
+#[command(help_template = "\
+{before-help}{name} ({version})
+{author-with-newline}{about-with-newline}
+{usage-heading} {usage}
+
+{all-args}{after-help}
+")]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Get the currently used version
+    Current {},
+    /// List the all installed versions of Node.js
+    List {},
+    /// List the all installed versions of Node.js
+    Ls {},
+    /// Use the installed version of Node.js (default is global)
+    Use {
+        /// The version number of Node.js
+        version: String,
+
+        /// Use version for project
+        #[arg(short, long)]
+        project: bool,
+    },
+    /// Get the path to the executable to where Node.js was installed
+    Which {
+        /// The version number of Node.js
+        version: String,
+    },
+}
+
+pub(super) fn command() -> Result<ExitStatus, String> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Some(Commands::Current {}) => {
+            eprintln!("v{}", *VERSION);
+        }
+        Some(Commands::Ls {}) | Some(Commands::List {}) => {
+            match command_for_list() {
+                Ok(()) => {}
+                Err(err) => {
+                    return Err(err.to_string());
+                }
+            };
+        }
+        Some(Commands::Use { version, project }) => {
+            if *project {
+                command_for_use_project(version);
+            } else {
+                command_for_use_global(version);
+            }
+        }
+        Some(Commands::Which { version }) => {
+            command_for_which(version);
+        }
+        None => {}
+    };
+
+    Ok(ExitStatus::from_raw(0))
+}
+
+fn command_for_list() -> Result<(), Error> {
+    let mut install_path = NVMD_PATH.clone();
+    install_path.push("versions");
+
+    let mut config = HashSet::new();
+    config.insert(DirEntryAttr::Name);
+
+    let ls_result = ls(install_path, &config)?;
+    let mut versions: Vec<String> = vec![];
+    for item in ls_result.items {
+        match item.get(&DirEntryAttr::Name) {
+            Some(DirEntryValue::String(version)) => {
+                versions.push(version.clone());
+            }
+            _ => {}
+        }
+    }
+    versions.sort_by(|a, b| match compare(b, a) {
+        Ok(Cmp::Lt) => Ordering::Less,
+        Ok(Cmp::Eq) => Ordering::Equal,
+        Ok(Cmp::Gt) => Ordering::Greater,
+        _ => unreachable!(),
+    });
+
+    for version in versions {
+        if version == *VERSION {
+            eprintln!("v{} (currently)", version);
+        } else {
+            eprintln!("v{}", version);
+        }
+    }
+
+    Ok(())
+}
+
+fn command_for_use_global(ver: &String) {
+    let mut version = ver.to_owned();
+    if version.starts_with("v") {
+        version.remove(0);
+    }
+
+    if !is_uninstall_version(&version) {
+        eprintln!("nvm-desktop: v{} has not been installed", &version);
+        return;
+    }
+
+    let mut default_path = NVMD_PATH.clone();
+    default_path.push("default");
+
+    match write_all(default_path, &version) {
+        Ok(()) => {
+            eprintln!("Now using node v{}", &version);
+        }
+        Err(err) => {
+            eprintln!("nvm-desktop: {}", err);
+        }
+    };
+}
+
+fn command_for_use_project(ver: &String) {
+    let mut version = ver.to_owned();
+    if version.starts_with("v") {
+        version.remove(0);
+    }
+
+    if !is_uninstall_version(&version) {
+        eprintln!("nvm-desktop: v{} has not been installed", &version);
+        return;
+    }
+
+    let mut nvmdrc_path = env::current_dir().unwrap();
+    nvmdrc_path.push(".nvmdrc");
+
+    match write_all(nvmdrc_path, &version) {
+        Ok(()) => {
+            eprintln!("Now using node v{}", &version);
+        }
+        Err(err) => {
+            eprintln!("nvm-desktop: {}", err);
+        }
+    };
+}
+
+fn command_for_which(ver: &String) {
+    let mut version = ver.to_owned();
+    if version.starts_with("v") {
+        version.remove(0);
+    }
+
+    let mut version_path = NVMD_PATH.clone();
+    version_path.push("versions");
+    version_path.push(&version);
+    if cfg!(unix) {
+        version_path.push("bin");
+    }
+
+    if version_path.exists() {
+        eprintln!("{:?}", version_path);
+    } else {
+        eprintln!("nvm-desktop: the version cannot be found: v{}", &version);
+    }
+}
+
+fn is_uninstall_version(version: &String) -> bool {
+    let mut version_path = NVMD_PATH.clone();
+    version_path.push("versions");
+    version_path.push(&version);
+    if cfg!(unix) {
+        version_path.push("bin");
+    }
+
+    version_path.exists()
+}

--- a/src/run/nvmd.rs
+++ b/src/run/nvmd.rs
@@ -15,7 +15,7 @@ use version_compare::{compare, Cmp};
 use crate::common::{NVMD_PATH, VERSION};
 
 #[derive(Parser)]
-#[command(name="nvmd", author="The1111mp@outlook.com", version="2.2.0", about="command tools for nvm-desktop", after_help="Please download new version of Node.js in nvm-desktop.", long_about = None)]
+#[command(name=env!("CARGO_PKG_NAME"), author=env!("CARGO_PKG_AUTHORS"), version=env!("CARGO_PKG_VERSION"), about="command tools for nvm-desktop", after_help="Please download new version of Node.js in nvm-desktop.", long_about = None)]
 #[command(help_template = "\
 {before-help}{name} ({version})
 {author-with-newline}{about-with-newline}


### PR DESCRIPTION
## Features:

- Support Command tools.
- Code refactoring to improve performance.

```shell
$ nvmd --help
nvmd (2.2.0)
The1111mp@outlook.com
command tools for nvm-desktop

Usage: nvmd [COMMAND]

Commands:
  current  Get the currently used version
  list     List the all installed versions of Node.js
  ls       List the all installed versions of Node.js
  use      Use the installed version of Node.js (default is global)
  which    Get the path to the executable to where Node.js was installed
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version

Please download new version of Node.js in nvm-desktop.
```