### PR TITLE
Fix `npm prefix` behavior & Track the behavior of corepack enable/disable commands.

### DIFF
--- a/src/run/binary.rs
+++ b/src/run/binary.rs
@@ -1,14 +1,13 @@
-use std::path::PathBuf;
-
 use super::{ExitStatus, OsStr, OsString};
 
 use crate::{
     command as CommandTool,
-    common::{BINARY_ENV_PATH, NPM_PREFIX},
+    common::{ENV_PATH, INSTALLTION_PATH, VERSION},
 };
 
 pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, String> {
-    let mut lib_path = PathBuf::from(NPM_PREFIX.clone());
+    let mut lib_path = INSTALLTION_PATH.clone();
+    lib_path.push(VERSION.clone());
     if cfg!(unix) {
         // unix
         lib_path.push("bin");
@@ -20,7 +19,7 @@ pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, Stri
     }
 
     let child = CommandTool::create_command(exe)
-        .env("PATH", BINARY_ENV_PATH.clone())
+        .env("PATH", ENV_PATH.clone())
         .args(args)
         .status();
 

--- a/src/run/corepack.rs
+++ b/src/run/corepack.rs
@@ -1,0 +1,122 @@
+use super::{ExitStatus, OsStr, OsString};
+
+use lazy_static::lazy_static;
+
+use crate::{
+    command as CommandTool,
+    common::{link_package, package_can_be_removed, unlink_package, ENV_PATH},
+};
+
+lazy_static! {
+    static ref ENABLE: OsString = OsString::from("enable");
+    static ref DISABLE: OsString = OsString::from("disable");
+    static ref INSTALL_DIRECTORY: OsString = OsString::from("--install-directory");
+}
+
+// corepack enable --install-directory /path/to/folder
+
+// When run, this commmand will check whether the shims for the specified package
+// managers can be found with the correct values inside the install directory. If
+// not, or if they don't exist, they will be created.
+
+// By default it will locate the install directory by running the equivalent of
+// `which corepack`, but this can be tweaked by explicitly passing the install
+// directory via the `--install-directory` flag.
+
+pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, String> {
+    if ENV_PATH.is_empty() {
+        return Err(String::from("command not found: ") + exe.to_str().unwrap());
+    }
+
+    let child = CommandTool::create_command(exe)
+        .env("PATH", ENV_PATH.clone())
+        .args(args)
+        .status();
+
+    match child {
+        Ok(status) => {
+            let install_directory = args.contains(&INSTALL_DIRECTORY);
+            // corepack enable ..
+            // No special handling is required when using the "--install-directory" option
+            if args.contains(&ENABLE) && !install_directory {
+                // let packages = &args.into_iter().filter(is_positional).collect();
+                corepack_enable(args);
+            }
+
+            // corepack disable ..
+            // No special handling is required when using the "--install-directory" option
+            if args.contains(&DISABLE) && !install_directory {
+                corepack_disable(args);
+            }
+
+            Ok(status)
+        }
+        Err(_) => Err(String::from("failed to execute process")),
+    }
+}
+
+fn corepack_enable(args: &[OsString]) {
+    let packages = &mut args
+        .into_iter()
+        .filter(is_positional)
+        .map(|name| String::from(name.to_str().unwrap()))
+        .collect::<Vec<String>>();
+
+    if packages.is_empty() {
+        packages.push(String::from("yarn"));
+        packages.push(String::from("pnpm"));
+    }
+
+    for package in packages {
+        link_package(package);
+        if package == "yarn" {
+            link_package(&String::from("yarnpkg"));
+        }
+        if package == "pnpm" {
+            link_package(&String::from("pnpx"));
+        }
+    }
+}
+
+fn corepack_disable(args: &[OsString]) {
+    let packages = &mut args
+        .into_iter()
+        .filter(is_positional)
+        .map(|name| String::from(name.to_str().unwrap()))
+        .collect::<Vec<String>>();
+
+    if packages.is_empty() {
+        packages.push(String::from("yarn"));
+        packages.push(String::from("pnpm"));
+    }
+
+    for package in packages {
+        if package_can_be_removed(package) {
+            // need to remove executable file
+            unlink_package(package);
+            if package == "yarn" {
+                unlink_package(&String::from("yarnpkg"));
+            }
+            if package == "pnpm" {
+                unlink_package(&String::from("pnpx"));
+            }
+        }
+    }
+}
+
+fn is_flag<A>(arg: &A) -> bool
+where
+    A: AsRef<OsStr>,
+{
+    match arg.as_ref().to_str() {
+        Some(a) => a == "yarn" || a == "pnpm",
+        None => false,
+    }
+}
+
+fn is_positional<A>(arg: &A) -> bool
+where
+    A: AsRef<OsStr>,
+{
+    is_flag(arg)
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 mod binary;
+mod corepack;
 mod engine;
 mod npm;
 mod nvmd;
@@ -19,7 +20,8 @@ pub fn execute() -> Result<ExitStatus, String> {
     match exe.to_str() {
         Some("nvmd") => nvmd::command(),
         Some("npm") => npm::command(&exe, &args),
-        Some("node") | Some("npx") | Some("corepack") => engine::command(&exe, &args),
+        Some("corepack") => corepack::command(&exe, &args),
+        Some("node") | Some("npx") => engine::command(&exe, &args),
         _ => binary::command(&exe, &args),
     }
 }

--- a/src/run/npm.rs
+++ b/src/run/npm.rs
@@ -353,7 +353,14 @@ where
     A: AsRef<OsStr>,
 {
     match arg.as_ref().to_str() {
-        Some(a) => a.starts_with('-') || a == "install" || a == "i" || a == "uninstall",
+        Some(a) => {
+            a.starts_with('-')
+                || a == "install"
+                || a == "i"
+                || a == "uninstall"
+                || a.starts_with("yarn")
+                || a.starts_with("pnpm")
+        }
         None => false,
     }
 }


### PR DESCRIPTION
# Fixes

- [c302655](https://github.com/1111mp/nvmd-command/commit/c302655) - Stop tracking the npm prefix directory as this is not the default behavior of the Node engine. [#23](https://github.com/1111mp/nvm-desktop/issues/23)
- [c893321](https://github.com/1111mp/nvmd-command/commit/c893321) - Track the behavior of corepack enable/disable commands. [#22](https://github.com/1111mp/nvm-desktop/issues/22)