### PR TITLE
Support `link` & `unlink` & `update` command for npm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +315,7 @@ dependencies = [
 name = "nvmd"
 version = "3.2.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["The1111mp@outlook.com"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.82"
 cfg-if = "1.0.0"
 chrono = "0.4.34"
 clap = { version = "4.5.1", features = ["derive"] }

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use serde_json::{from_str, json, Value};
 #[cfg(unix)]
 use std::os::unix::fs;
-use std::{env, ffi::OsString, io::ErrorKind, path::PathBuf, process::ExitStatus};
+use std::{env, ffi::OsString, io::ErrorKind, path::PathBuf};
 
 lazy_static! {
     pub static ref NVMD_PATH: PathBuf = get_nvmd_path();
@@ -236,29 +236,4 @@ fn default_home_dir() -> Result<PathBuf, ErrorKind> {
     let mut home = dirs::home_dir().ok_or(ErrorKind::NotFound)?;
     home.push(".nvmd");
     Ok(home)
-}
-
-pub enum Error {
-    Message(String),
-    Code(i32),
-}
-
-pub trait IntoResult<T> {
-    fn into_result(self) -> Result<T, Error>;
-}
-
-impl IntoResult<()> for Result<ExitStatus, String> {
-    fn into_result(self) -> Result<(), Error> {
-        match self {
-            Ok(status) => {
-                if status.success() {
-                    Ok(())
-                } else {
-                    let code = status.code().unwrap_or(1);
-                    Err(Error::Code(code))
-                }
-            }
-            Err(err) => Err(Error::Message(err)),
-        }
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,20 +4,20 @@ mod command;
 mod common;
 mod run;
 
-use common::{Error, IntoResult};
 use run::execute;
 
 fn main() {
-    let result = execute().into_result();
+    let result = execute();
     match result {
-        Ok(()) => {
-            process::exit(0);
-        }
-        Err(Error::Code(code)) => {
+        Ok(exit_status) => {
+            // If the code method returns None (meaning the process exited due to receiving a signal)
+            // Extract the exit code, using the default value 0 if the process terminated due to a signal
+            let code = exit_status.code().unwrap_or(0);
             process::exit(code);
         }
-        Err(Error::Message(msg)) => {
-            eprintln!("nvm-desktop: {}", msg);
+        Err(error) => {
+            // Print error messages to standard error output
+            eprintln!("nvm-desktop: {}", error);
             process::exit(1);
         }
     }

--- a/src/run/engine.rs
+++ b/src/run/engine.rs
@@ -1,19 +1,17 @@
+use super::{anyhow, Result};
 use super::{ExitStatus, OsStr, OsString};
 
 use crate::{command as CommandTool, common::ENV_PATH};
 
-pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus, String> {
+pub(super) fn command(exe: &OsStr, args: &[OsString]) -> Result<ExitStatus> {
     if ENV_PATH.is_empty() {
-        return Err(String::from("command not found: ") + exe.to_str().unwrap());
+        return Err(anyhow!("command not found: {:?}", exe));
     }
 
-    let child = CommandTool::create_command(exe)
+    let status = CommandTool::create_command(exe)
         .env("PATH", ENV_PATH.clone())
         .args(args)
-        .status();
+        .status()?;
 
-    match child {
-        Ok(status) => Ok(status),
-        Err(_) => Err(String::from("failed to execute process")),
-    }
+    Ok(status)
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use std::{
     env::{self, ArgsOs},
     ffi::{OsStr, OsString},
@@ -12,7 +13,7 @@ mod engine;
 mod npm;
 mod nvmd;
 
-pub fn execute() -> Result<ExitStatus, String> {
+pub fn execute() -> Result<ExitStatus> {
     let mut native_args = env::args_os();
     let exe = get_tool_name(&mut native_args).expect("get tool name error");
     let args: Vec<_> = native_args.collect();

--- a/src/run/nvmd.rs
+++ b/src/run/nvmd.rs
@@ -1,5 +1,6 @@
 use super::ExitStatus;
-use anyhow::{anyhow, Result};
+use super::{anyhow, Result};
+
 use chrono::Local;
 use clap::{Parser, Subcommand};
 use fs_extra::{
@@ -62,7 +63,7 @@ enum Commands {
     },
 }
 
-pub(super) fn command() -> Result<ExitStatus, String> {
+pub(super) fn command() -> Result<ExitStatus> {
     let cli = Cli::parse();
 
     let ret = match &cli.command {
@@ -87,7 +88,7 @@ pub(super) fn command() -> Result<ExitStatus, String> {
 
     match ret {
         Ok(_) => Ok(ExitStatus::from_raw(0)),
-        Err(err) => Err(err.to_string()),
+        Err(err) => Err(err),
     }
 }
 


### PR DESCRIPTION
# Features

- [96f4acf](https://github.com/1111mp/nvmd-command/commit/96f4acf) - Support `link` & `unlink` & `update` command for npm. (https://github.com/1111mp/nvm-desktop/issues/78)
- [9191b38](https://github.com/1111mp/nvmd-command/commit/9191b38) - Aliases that npm supports for the install & uninstall command.
- [e29f8f7](https://github.com/1111mp/nvmd-command/commit/e29f8f7) - Supports the function of specifying groups for projects. (https://github.com/1111mp/nvm-desktop/discussions/76)

# Fixes

- [e10f434](https://github.com/1111mp/nvmd-command/commit/e10f434) - The `link` command support using relative paths.
- [e29f8f7](https://github.com/1111mp/nvmd-command/commit/e29f8f7) - Executing the `nvmd use {version} --project` command when `projects.json` already contains content will not add a new `project`.
- [19903a8](https://github.com/1111mp/nvmd-command/commit/19903a8) - Use `anyhow` to rewrite the error handling process.